### PR TITLE
Add a variable to configure the number of threads used

### DIFF
--- a/docker_settings.yaml
+++ b/docker_settings.yaml
@@ -11,6 +11,7 @@ admin:
 
 addresses:
   oa:
+    nb_threads: 4
     download:
       - lu/countrywide
 

--- a/invoke.yaml
+++ b/invoke.yaml
@@ -45,10 +45,12 @@ addresses:
     download: # List of openaddresses datasets to download
       # - lu/countrywide
       # - fr/paris
+    nb_threads: # number of threads to use
 
   bano:
     file: # PATH to the bano file, ignored if url is defined
     url: #https://bano.openstreetmap.fr/data/full.csv.gz
+    nb_threads: # number of threads to use
 
 ## name of the geocoder region to run. default is france
 # geocoder_tester_region: luxembourg

--- a/tasks.py
+++ b/tasks.py
@@ -148,6 +148,9 @@ def load_addresses(ctx, files=[]):
 
     if addr_config.get('bano', {}).get('file'):
         logging.info("importing bano addresses")
+
+        nb_threads_conf = ctx.addresses.bano.get("nb_threads")
+        nb_threads = "--nb-threads {}".format(nb_threads_conf) if nb_threads_conf else ""
         run_rust_binary(
             ctx,
             "mimir",
@@ -155,12 +158,15 @@ def load_addresses(ctx, files=[]):
             files,
             "--input {ctx.addresses.bano.file} \
             --connection-string {ctx.es} \
+            {nb_threads} \
             --dataset {ctx.dataset}".format(
-                ctx=ctx
+                ctx=ctx, nb_threads=nb_threads
             ),
         )
     if addr_config.get('oa', {}).get('file'):
         logging.info("importing oa addresses")
+        nb_threads_conf = ctx.addresses.oa.get("nb_threads")
+        nb_threads = "--nb-threads {}".format(nb_threads_conf) if nb_threads_conf else ""
         # TODO take multiples oa files ?
         run_rust_binary(
             ctx,
@@ -169,8 +175,9 @@ def load_addresses(ctx, files=[]):
             files,
             "--input {ctx.addresses.oa.file} \
             --connection-string {ctx.es} \
+            {nb_threads} \
             --dataset {ctx.dataset}".format(
-                ctx=ctx
+                ctx=ctx, nb_threads=nb_threads
             ),
         )
 


### PR DESCRIPTION
add a nb_threads to set the number of threads used by either oa or bano

```yaml
addresses:
  oa:
    nb_threads: 4
```

linked to https://github.com/CanalTP/mimirsbrunn/pull/255