### PR TITLE
cleanup import order

### DIFF
--- a/download/tasks.py
+++ b/download/tasks.py
@@ -4,10 +4,12 @@ import tempfile
 
 from invoke import task
 
+
 @task
 def download_osm(ctx, osm_url, output_file):
     ctx.run(f"mkdir -p {path.dirname(output_file)}")
     ctx.run(f"wget --progress=dot:giga {osm_url} -O {output_file}")
+
 
 @task
 def download_bano(ctx, bano_url, output_file):
@@ -16,12 +18,13 @@ def download_bano(ctx, bano_url, output_file):
     ctx.run(f"wget --progress=dot:giga {bano_url} -O {gzip_file}")
     ctx.run(f"gunzip -f {gzip_file}")
 
+
 @task
 def download_oa(ctx, oa_files):
     temp_dir = tempfile.mkdtemp()
 
-    oa_files = oa_files.split(',')
-    oa_temp_dir = path.join(temp_dir, 'oa')
+    oa_files = oa_files.split(",")
+    oa_temp_dir = path.join(temp_dir, "oa")
 
     for oa_filename in oa_files:
         source_url = f"{ctx.oa_base_url}{oa_filename}.zip"
@@ -31,12 +34,11 @@ def download_oa(ctx, oa_files):
         ctx.run(f"unzip -o -qq -d {oa_temp_dir} {tmp_file}")
         ctx.run(f"rm {tmp_file}")
 
-    output_dir = path.join(ctx.data_dir, 'addresses', 'oa')
+    output_dir = path.join(ctx.data_dir, "addresses", "oa")
     ctx.run(f"rm -rf {output_dir}")
     ctx.run(f"mkdir -p {output_dir}")
 
     # Flatten all .csv to the root of a single directory
     for csv_file in glob.glob(f"{oa_temp_dir}/**/*.csv", recursive=True):
-        flat_csv_filename = csv_file.lstrip(oa_temp_dir).replace('/', '__')
+        flat_csv_filename = csv_file.lstrip(oa_temp_dir).replace("/", "__")
         ctx.run(f"mv {csv_file} {output_dir}/{flat_csv_filename}")
-

--- a/runner/tasks.py
+++ b/runner/tasks.py
@@ -209,12 +209,7 @@ def run_all(ctx, url=None, name="geocoder-tester", regions=None):
 
     report_file = os.path.join(ctx.output_dir, f"report.json")
     with open(report_file, "w") as log_file:
-        data = {
-            'name': name,
-            'url': url,
-            'version': version,
-            'md_report': report
-        }
+        data = {"name": name, "url": url, "version": version, "md_report": report}
         log_file.write(json.dumps(data, indent=2))
 
     # print also a csv to better compare the results

--- a/tasks.py
+++ b/tasks.py
@@ -27,37 +27,40 @@ def run_rust_binary(ctx, container, bin, files, params):
         )
     )
 
+
 @task()
 def download(ctx, files=[]):
-    if not ctx.get("run_on_docker_compose") \
-       and any((ctx.osm.url, ctx.addresses.bano.url, ctx.addresses.oa.download)):
-       raise Exception('Cannot download datasets when not running on docker-compose')
+    if not ctx.get("run_on_docker_compose") and any(
+        (ctx.osm.url, ctx.addresses.bano.url, ctx.addresses.oa.download)
+    ):
+        raise Exception("Cannot download datasets when not running on docker-compose")
 
     files_args = _build_docker_files_args(files)
 
     if ctx.osm.url:
         file_name = os.path.basename(ctx.osm.url)
-        ctx.osm.file = os.path.join('/data/osm', file_name)
+        ctx.osm.file = os.path.join("/data/osm", file_name)
         ctx.run(
-            'docker-compose {files} run --rm download'
-            ' download-osm --osm-url={osm_url} --output-file={output_file}'.format(
+            "docker-compose {files} run --rm download"
+            " download-osm --osm-url={osm_url} --output-file={output_file}".format(
                 files=files_args, osm_url=ctx.osm.url, output_file=ctx.osm.file
             )
         )
     if ctx.addresses.bano.url:
         ctx.addresses.bano.file = "/data/addresses/bano.csv"
         ctx.run(
-            'docker-compose {files} run --rm download'
-            ' download-bano --bano-url={bano_url} --output-file={output_file}'.format(
-                files=files_args, bano_url=ctx.addresses.bano.url,
-                output_file=ctx.addresses.bano.file
+            "docker-compose {files} run --rm download"
+            " download-bano --bano-url={bano_url} --output-file={output_file}".format(
+                files=files_args,
+                bano_url=ctx.addresses.bano.url,
+                output_file=ctx.addresses.bano.file,
             )
         )
     if ctx.addresses.oa.download:
         ctx.addresses.oa.file = "/data/addresses/oa"
         ctx.run(
-            'docker-compose {files} run --rm download'
-            ' download-oa --oa-files={oa_files}'.format(
+            "docker-compose {files} run --rm download"
+            " download-oa --oa-files={oa_files}".format(
                 files=files_args, oa_files=",".join(ctx.addresses.oa.download)
             )
         )
@@ -129,9 +132,11 @@ def load_osm(ctx, files=[]):
             for lvl in osm_args["levels"]:
                 admin_args += " --level {}".format(lvl)
             admin_args += _get_cli_param(osm_args.get("nb_shards"), "--nb-admin-shards")
-            admin_args += _get_cli_param(osm_args.get("nb_replicas"), "--nb-admin-replicas")
+            admin_args += _get_cli_param(
+                osm_args.get("nb_replicas"), "--nb-admin-replicas"
+            )
 
-    poi_conf = ctx.get("poi", {}).get('osm')
+    poi_conf = ctx.get("poi", {}).get("osm")
     poi_args = ""
     if poi_conf:
         poi_args = "--import-poi"
@@ -139,8 +144,12 @@ def load_osm(ctx, files=[]):
         poi_args += _get_cli_param(poi_conf.get("nb_replicas"), "--nb-poi-replicas")
 
     street_conf = ""
-    street_conf += _get_cli_param(ctx.get('street', {}).get("nb_shards"), "--nb-street-shards")
-    street_conf += _get_cli_param(ctx.get('street', {}).get("nb_replicas"), "--nb-street-replicas")
+    street_conf += _get_cli_param(
+        ctx.get("street", {}).get("nb_shards"), "--nb-street-shards"
+    )
+    street_conf += _get_cli_param(
+        ctx.get("street", {}).get("nb_replicas"), "--nb-street-replicas"
+    )
 
     run_rust_binary(
         ctx,
@@ -167,7 +176,7 @@ def load_addresses(ctx, files=[]):
         logging.info("no addresses to import")
         return
 
-    if addr_config.get('bano', {}).get('file'):
+    if addr_config.get("bano", {}).get("file"):
         logging.info("importing bano addresses")
         conf = ctx.addresses.bano
         additional_params = _get_cli_param(conf.get("nb_threads"), "--nb-threads")
@@ -185,7 +194,7 @@ def load_addresses(ctx, files=[]):
                 ctx=ctx, additional_params=additional_params
             ),
         )
-    if addr_config.get('oa', {}).get('file'):
+    if addr_config.get("oa", {}).get("file"):
         logging.info("importing oa addresses")
         conf = ctx.addresses.oa
         additional_params = _get_cli_param(conf.get("nb_threads"), "--nb-threads")
@@ -223,7 +232,9 @@ def load_fafnir_pois(ctx, files=[]):
         logging.warn("for the moment we can't load data in postgres for fafnir")
 
     additional_params = _get_cli_param(fafnir_conf.get("nb_threads"), "--nb-threads")
-    additional_params += _get_cli_param(fafnir_conf.get("bounding-box"), "--bounding-box")
+    additional_params += _get_cli_param(
+        fafnir_conf.get("bounding-box"), "--bounding-box"
+    )
     additional_params += _get_cli_param(fafnir_conf.get("nb_shards"), "--nb-shards")
     additional_params += _get_cli_param(fafnir_conf.get("nb_replicas"), "--nb-replicas")
 
@@ -316,12 +327,16 @@ def test(ctx, files=None):
     ctx.run("docker-compose -f tester_docker-compose.yml build")
     files_args = _build_docker_files_args(["tester_docker-compose.yml"] + files)
 
-    region = ctx.get('geocoder_tester_region')
+    region = ctx.get("geocoder_tester_region")
     if region:
         additional_args = "run-all --regions {}".format(region)
     else:
         additional_args = ""
-    ctx.run("docker-compose {files} run --rm geocoder-tester-runner {args}".format(files=files_args, args=additional_args))
+    ctx.run(
+        "docker-compose {files} run --rm geocoder-tester-runner {args}".format(
+            files=files_args, args=additional_args
+        )
+    )
 
 
 @retry(stop_max_delay=60000, wait_fixed=100)


### PR DESCRIPTION
we now, for all, import the data in this order:

 - admin (from cosmogony or osm)
 - addresses (from bano or OA)
 - streets from osm
 - pois (from fafnir or osm)

this way all objects are correctly associated with an admin (and pois can be reverse geocoded)

the osm file will be read 3 times in the kisio's scenario, but since the file reading takes 5mn for a french setup, I think it's acceptable for a 2h run.


Note: there is also a black formating commit that can be skipped for easier review