### PR TITLE
Define settings to pass lang codes to cosmogony2mimir

### DIFF
--- a/invoke.yaml
+++ b/invoke.yaml
@@ -21,6 +21,7 @@ osm: # A file or a url MUST be defined
 #     directory:
 #     nb_shards:  # control the number of shards of the ES index
 #     nb_replicas:  # control the number of replicas of the ES index
+#     langs: # languages to import i18n names and labels (codes separated by ,)
 #   ## If present will use the admins from osm
 #   osm:
 #     levels:

--- a/tasks.py
+++ b/tasks.py
@@ -97,17 +97,27 @@ def load_cosmogony(ctx, files=[]):
     conf = ctx.admin.cosmogony
     additional_params = _get_cli_param(conf.get("nb_shards"), "--nb-shards")
     additional_params += _get_cli_param(conf.get("nb_replicas"), "--nb-replicas")
+
+    langs_params = ""
+    if ctx.admin.cosmogony.langs:
+        langs_codes = ctx.admin.cosmogony.langs.split(',')
+        for code in langs_codes:
+            langs_params += _get_cli_param(code, "--lang")
+
     run_rust_binary(
         ctx,
         "mimir",
         "cosmogony2mimir",
         files,
         "--input {ctx.admin.cosmogony.file} \
+        {langs_params} \
         --connection-string {ctx.es} \
         --dataset {ctx.dataset} \
         {additional_params} \
         ".format(
-            ctx=ctx, additional_params=additional_params
+            ctx=ctx,
+            langs_params=langs_params,
+            additional_params=additional_params
         ),
     )
 


### PR DESCRIPTION
Following https://github.com/CanalTP/mimirsbrunn/pull/285

In order to import names and labels with admins, for all languages that are currently supported in Erdapfel, we will use : 

```yaml
 admin:
  cosmogony:
    langs: en,de,fr,es,it,br,ca
```