### PR TITLE
Implement new options for cosmogony and osm2mimir

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,8 +38,7 @@ services:
   fafnir:
     image: qwantresearch/fafnir
     environment:
-      - RUST_LOG=info,hyper=warn,rs_es=warn
-
+      - RUST_LOG=warn,fafnir=info,mimir=info
 
 volumes:
   osm:

--- a/docker_settings.yaml
+++ b/docker_settings.yaml
@@ -2,12 +2,18 @@
 
 es: http://es:9200
 
+run_on_docker_compose: true
+
 osm:
   url: https://download.geofabrik.de/europe/luxembourg-latest.osm.pbf
 
 admin:
   cosmogony:
     output_dir: /data/cosmogony
+    langs: "fr,en,de"
+
+street:
+  osm_db_file: /data/osm/osm_db.tmp
 
 addresses:
   oa:

--- a/invoke.yaml
+++ b/invoke.yaml
@@ -22,6 +22,7 @@ osm: # A file or a url MUST be defined
 #     nb_shards:  # control the number of shards of the ES index
 #     nb_replicas:  # control the number of replicas of the ES index
 #     langs: # languages to import i18n names and labels (codes separated by ,)
+#     disable_voronoi:  # set to truthy value to disable voronoi geometries generation
 #   ## If present will use the admins from osm
 #   osm:
 #     levels:
@@ -69,6 +70,7 @@ addresses:
 # street:
 #   nb_shards:  # control the number of shards of the ES index
 #   nb_replicas:  # control the number of replicas of the ES index
+#   osm_db_file:  # temporary file to write osm db and reduce memory usage  (optional)
 
 ## name of the geocoder region to run. default is france
 # geocoder_tester_region: luxembourg


### PR DESCRIPTION
Implement new options in import pipeline
* `--db-file` for osm2mimir (https://github.com/CanalTP/mimirsbrunn/pull/350)
* `--disable-voronoi` for cosmogony
* `--filter-langs` for cosmogony