### PR TITLE
Update load_addresses task to use the new global importer

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,15 @@ pipenv run inv -f docker_settings.yaml load-in-docker-and-test
 #### About Tests
 
 - If you don't want to run the tests you can also use `invoke` chaining calls:
+
 ```
 pipenv run inv -f docker_settings.yaml compose-up load-all compose-down
 ```
+
 - Some other `docker-compose` files can also be given (this will use [the docker compose override mechanism](https://docs.docker.com/compose/extends/#different-environments)). It will for example make it possible to use customly build image to run tests on a given Mimir (or [Fafnir](https://github.com/QwantResearch/fafnir), [Cosmogony](https://github.com/osm-without-borders/cosmogony), ...) branch.
 
 - The file paths are given with the `--files` arguments, as follows:
+
 ```
 pipenv run inv -f docker_settings.yaml load-in-docker-and-test --files my-docker-compose.yml --files my-other-compose.yml
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,9 @@ services:
     environment:
       - RUST_LOG=warn,fafnir=info,mimir=info
 
+  addresses-importer:
+    image: qwantresearch/addresses-importer
+
 volumes:
   osm:
   cosmogony:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,9 @@ services:
 
   addresses-importer:
     image: qwantresearch/addresses-importer
+    volumes:
+      - ${OSM_DIR:-osm}:/data/osm
+      - ${ADDR_DIR:-addr}:/data/addresses
 
 volumes:
   osm:

--- a/docker_settings.yaml
+++ b/docker_settings.yaml
@@ -3,7 +3,7 @@
 es: http://es:9200
 
 osm:
-  url: https://download.geofabrik.de/europe/luxembourg-latest.osm.pbf
+  url: https://download.geofabrik.de/europe/belgium-latest.osm.pbf
 
 admin:
   cosmogony:

--- a/docker_settings.yaml
+++ b/docker_settings.yaml
@@ -3,7 +3,7 @@
 es: http://es:9200
 
 osm:
-  url: https://download.geofabrik.de/europe/belgium-latest.osm.pbf
+  url: https://download.geofabrik.de/europe/luxembourg-latest.osm.pbf
 
 admin:
   cosmogony:

--- a/docker_settings.yaml
+++ b/docker_settings.yaml
@@ -14,6 +14,8 @@ street:
   osm_db_file: /data/osm/osm_db.tmp
 
 addresses:
+  use_deduplicator: false
+
   oa:
     # URL for the zip archive containing all data.
     url: https://data.openaddresses.io/openaddr-collected-europe.zip

--- a/invoke.yaml
+++ b/invoke.yaml
@@ -50,6 +50,8 @@ osm: # A file or a url MUST be defined
 #     nb_shards:  # control the number of shards of the ES index
 #     nb_replicas:  # control the number of replicas of the ES index
 
+new-importer: false
+
 addresses:
   oa:
     file: # Path to .csv, or a directory with multiple .csv (ignored if 'download' is defined)
@@ -66,7 +68,10 @@ addresses:
     nb_threads: # number of threads to use
 #   nb_shards:  # control the number of shards of the ES index
 #   nb_replicas:  # control the number of replicas of the ES index
-  osm: true
+
+  osm:
+    file: # PATH to the pbf file, ignored is url is defined
+    url:  # geofabrik
 
 # street:
 #   nb_shards:  # control the number of shards of the ES index

--- a/invoke.yaml
+++ b/invoke.yaml
@@ -50,9 +50,9 @@ osm: # A file or a url MUST be defined
 #     nb_shards:  # control the number of shards of the ES index
 #     nb_replicas:  # control the number of replicas of the ES index
 
-new-importer: false
-
 addresses:
+  use_deduplicator: false
+
   oa:
     file: # Path to .csv, or a directory with multiple .csv (ignored if 'download' is defined)
     download: # List of openaddresses datasets to download

--- a/invoke.yaml
+++ b/invoke.yaml
@@ -69,10 +69,6 @@ addresses:
 #   nb_shards:  # control the number of shards of the ES index
 #   nb_replicas:  # control the number of replicas of the ES index
 
-  osm:
-    file: # PATH to the pbf file, ignored is url is defined
-    url:  # geofabrik
-
 # street:
 #   nb_shards:  # control the number of shards of the ES index
 #   nb_replicas:  # control the number of replicas of the ES index

--- a/invoke.yaml
+++ b/invoke.yaml
@@ -66,6 +66,7 @@ addresses:
     nb_threads: # number of threads to use
 #   nb_shards:  # control the number of shards of the ES index
 #   nb_replicas:  # control the number of replicas of the ES index
+  osm: true
 
 # street:
 #   nb_shards:  # control the number of shards of the ES index

--- a/tasks.py
+++ b/tasks.py
@@ -273,12 +273,12 @@ def load_addresses(ctx, files=[]):
         options.append(ctx.osm.file)
     if len(options) == 0:
         return
-    options.append("--output_compressed_csv")
-    options.append("/addr/{}".format(output_csv))
+    options.append("--output-compressed-csv")
+    options.append("/data/{}".format(output_csv))
 
     logging.info("Running addresses importer/deduplicator")
 
-    run_rust_binary(ctx, "addresses-importer", "deduplicator", options)
+    run_rust_binary(ctx, "addresses-importer", "", files, ' '.join(options))
 
     logging.info("Import addresses into ES instance")
 
@@ -287,11 +287,11 @@ def load_addresses(ctx, files=[]):
         "mimir",
         "openaddresses2mimir",
         files,
-        "--input {output_csv} \
+        "--input /data/{output_csv} \
         --connection-string {ctx.es} \
-        {additional_params} \
         --dataset {ctx.dataset}".format(
-            ctx=ctx, additional_params=additional_params
+            ctx=ctx,
+            output_csv=output_csv
         ),
     )
 

--- a/tasks.py
+++ b/tasks.py
@@ -274,7 +274,7 @@ def load_addresses(ctx, files=[]):
     if len(options) == 0:
         return
     options.append("--output-compressed-csv")
-    options.append("/data/{}".format(output_csv))
+    options.append("/data/addresses/{}".format(output_csv))
 
     logging.info("Running addresses importer/deduplicator")
 
@@ -290,7 +290,7 @@ def load_addresses(ctx, files=[]):
         "mimir",
         "openaddresses2mimir",
         files,
-        "--input /data/{output_csv} \
+        "--input /data/addresses/{output_csv} \
         --connection-string {ctx.es} \
         {additional_params} \
         --dataset {ctx.dataset}".format(

--- a/tasks.py
+++ b/tasks.py
@@ -31,7 +31,7 @@ def run_rust_binary(ctx, container, bin, files, params):
 def download(ctx, files=[]):
     files_args = _build_docker_files_args(files)
 
-    if ctx.osm.url:
+    if ctx.get("osm", {}).get("url"):
         file_name = os.path.basename(ctx.osm.url)
         ctx.osm.file = os.path.join("/data/osm", file_name)
         ctx.run(
@@ -40,7 +40,7 @@ def download(ctx, files=[]):
                 files=files_args, osm_url=ctx.osm.url, output_file=ctx.osm.file
             )
         )
-    if ctx.addresses.bano.url:
+    if ctx.addresses.get("bano", {}).get("url"):
         ctx.addresses.bano.file = "/data/addresses/bano.csv"
         ctx.run(
             "docker-compose {files} run --rm download"
@@ -50,7 +50,7 @@ def download(ctx, files=[]):
                 output_file=ctx.addresses.bano.file,
             )
         )
-    if ctx.addresses.oa.url and ctx.addresses.oa.include:
+    if ctx.addresses.get("oa", {}).get("url") and ctx.addresses.get("oa", {}).get("include"):
         ctx.addresses.oa.path = "/data/addresses/oa"
         ctx.run(
             "docker-compose {files} run --rm download"
@@ -268,9 +268,9 @@ def load_addresses(ctx, files=[]):
     if ctx.addresses.get("oa", {}).get("file"):
         options.append("--openaddresses")
         options.append(ctx.addresses.oa.file)
-    if ctx.addresses.get("osm", {}).get("file"):
+    if ctx.get("osm", {}).get("file"):
         options.append("--osm")
-        options.append(ctx.addresses.osm.file)
+        options.append(ctx.osm.file)
     if len(options) == 0:
         return
     options.append("--output_compressed_csv")

--- a/tasks.py
+++ b/tasks.py
@@ -262,17 +262,12 @@ def load_addresses(ctx, files=[]):
     output_csv = "output.csv.gz"
 
     options = []
-    additional_params = ''
     if ctx.addresses.get("bano", {}).get("file"):
         options.append("--bano")
         options.append(ctx.addresses.bano.file)
     if ctx.addresses.get("oa", {}).get("file"):
         options.append("--openaddresses")
         options.append(ctx.addresses.oa.file)
-        conf = ctx.addresses.oa
-        additional_params = _get_cli_param(conf.get("nb_threads"), "--nb-threads")
-        additional_params += _get_cli_param(conf.get("nb_shards"), "--nb-shards")
-        additional_params += _get_cli_param(conf.get("nb_replicas"), "--nb-replicas")
     if ctx.get("osm", {}).get("file"):
         options.append("--osm")
         options.append(ctx.osm.file)
@@ -287,6 +282,9 @@ def load_addresses(ctx, files=[]):
 
     logging.info("Import addresses into ES instance")
 
+    additional_params = _get_cli_param(ctx.addresses.get("oa", {}).get("nb_threads"), "--nb-threads")
+    additional_params += _get_cli_param(ctx.addresses.get("oa", {}).get("nb_shards"), "--nb-shards")
+    additional_params += _get_cli_param(ctx.addresses.get("oa", {}).get("nb_replicas"), "--nb-replicas")
     run_rust_binary(
         ctx,
         "mimir",

--- a/tasks.py
+++ b/tasks.py
@@ -219,7 +219,7 @@ def load_addresses(ctx, files=[]):
         logging.info("no addresses to import")
         return
 
-    if ctx.get("new-importer", False) is False:
+    if not ctx.get("new-importer", False):
         addr_config = ctx.get("addresses")
         if addr_config.get("bano", {}).get("file"):
             logging.info("importing bano addresses")

--- a/tasks.py
+++ b/tasks.py
@@ -224,7 +224,6 @@ def load_addresses(ctx, files=[]):
         if addr_config.get("bano", {}).get("file"):
             logging.info("importing bano addresses")
             conf = ctx.addresses.bano
-
             additional_params = _get_cli_param(conf.get("nb_threads"), "--nb-threads")
             additional_params += _get_cli_param(conf.get("nb_shards"), "--nb-shards")
             additional_params += _get_cli_param(conf.get("nb_replicas"), "--nb-replicas")
@@ -240,19 +239,18 @@ def load_addresses(ctx, files=[]):
                     ctx=ctx, additional_params=additional_params
                 ),
             )
-        if addr_config.get("oa", {}).get("file"):
+        if addr_config.get("oa", {}).get("path"):
             logging.info("importing oa addresses")
             conf = ctx.addresses.oa
             additional_params = _get_cli_param(conf.get("nb_threads"), "--nb-threads")
             additional_params += _get_cli_param(conf.get("nb_shards"), "--nb-shards")
             additional_params += _get_cli_param(conf.get("nb_replicas"), "--nb-replicas")
-            # TODO take multiples oa files ?
-             run_rust_binary(
+            run_rust_binary(
                 ctx,
                 "mimir",
                 "openaddresses2mimir",
                 files,
-                "--input {ctx.addresses.oa.file} \
+                "--input {ctx.addresses.oa.path} \
                 --connection-string {ctx.es} \
                 {additional_params} \
                 --dataset {ctx.dataset}".format(
@@ -276,7 +274,7 @@ def load_addresses(ctx, files=[]):
     if len(options) == 0:
         return
     options.append("--output_compressed_csv")
-    options.append(f"/addr/{output_csv}")
+    options.append("/addr/{}".format(output_csv))
 
     logging.info("Running addresses importer/deduplicator")
 

--- a/tasks.py
+++ b/tasks.py
@@ -219,7 +219,7 @@ def load_addresses(ctx, files=[]):
         logging.info("no addresses to import")
         return
 
-    if not ctx.get("new-importer", False):
+    if not ctx.addresses.get("use_deduplicator", False):
         addr_config = ctx.get("addresses")
         if addr_config.get("bano", {}).get("file"):
             logging.info("importing bano addresses")
@@ -262,12 +262,17 @@ def load_addresses(ctx, files=[]):
     output_csv = "output.csv.gz"
 
     options = []
+    additional_params = ''
     if ctx.addresses.get("bano", {}).get("file"):
         options.append("--bano")
         options.append(ctx.addresses.bano.file)
     if ctx.addresses.get("oa", {}).get("file"):
         options.append("--openaddresses")
         options.append(ctx.addresses.oa.file)
+        conf = ctx.addresses.oa
+        additional_params = _get_cli_param(conf.get("nb_threads"), "--nb-threads")
+        additional_params += _get_cli_param(conf.get("nb_shards"), "--nb-shards")
+        additional_params += _get_cli_param(conf.get("nb_replicas"), "--nb-replicas")
     if ctx.get("osm", {}).get("file"):
         options.append("--osm")
         options.append(ctx.osm.file)
@@ -289,9 +294,11 @@ def load_addresses(ctx, files=[]):
         files,
         "--input /data/{output_csv} \
         --connection-string {ctx.es} \
+        {additional_params} \
         --dataset {ctx.dataset}".format(
+            output_csv=output_csv,
             ctx=ctx,
-            output_csv=output_csv
+            additional_params=additional_params
         ),
     )
 


### PR DESCRIPTION
We need to push the "addresses-importer" image, but otherwise I think it's globally "correct".