### PR TITLE
Pass through the poi-config option when importing POIs.

### DIFF
--- a/invoke.yaml
+++ b/invoke.yaml
@@ -47,6 +47,7 @@ osm: # A file or a url MUST be defined
 #     langs: # languages to import i18n names and labels (codes separated by ,)
 #   ## If present will use osm2mimir to import the poi
 #   osm:
+#     poi_config: # optional path to json file with POI-config and filters
 #     nb_shards:  # control the number of shards of the ES index
 #     nb_replicas:  # control the number of replicas of the ES index
 

--- a/tasks.py
+++ b/tasks.py
@@ -179,6 +179,7 @@ def load_osm_pois(ctx, files=[]):
     if poi_conf:
         poi_args += _get_cli_param(poi_conf.get("nb_shards"), "--nb-poi-shards")
         poi_args += _get_cli_param(poi_conf.get("nb_replicas"), "--nb-poi-replicas")
+        poi_args += _get_cli_param(poi_conf.get("poi_config"), "--poi-config")
 
     run_rust_binary(
         ctx,


### PR DESCRIPTION
This allows a user to configure what POIs are to be imported and how
they are named and filtered. poi-config is an undocumented feature, but
important when indexing POIs.