### PR TITLE
add a separate setting for OSM file to import addresses from

### DIFF
--- a/docker_settings.yaml
+++ b/docker_settings.yaml
@@ -16,6 +16,9 @@ street:
 addresses:
   use_deduplicator: false
 
+  osm:
+    url: # https://download.geofabrik.de/europe/luxembourg-latest.osm.pbf
+
   oa:
     # URL for the zip archive containing all data.
     url: https://data.openaddresses.io/openaddr-collected-europe.zip

--- a/invoke.yaml
+++ b/invoke.yaml
@@ -54,20 +54,27 @@ addresses:
   use_deduplicator: false
 
   oa:
-    file: # Path to .csv, or a directory with multiple .csv (ignored if 'download' is defined)
-    download: # List of openaddresses datasets to download
-      # - lu/countrywide
-      # - fr/paris
+    path: # Path to .csv, or a directory with multiple .csv (ignored if 'url' is defined)
+    url: # Url where to download OpenAddresses data
+    include: # List of file patterns to include from path
+      - lu/**.csv
+      # - fr/**.csv
     nb_threads: # number of threads to use
 #   nb_shards:  # control the number of shards of the ES index
 #   nb_replicas:  # control the number of replicas of the ES index
 
   bano:
-    file: # PATH to the bano file, ignored if url is defined
-    url: #https://bano.openstreetmap.fr/data/full.csv.gz
+    file: # Path to the bano file, ignored if url is defined
+    url: # https://bano.openstreetmap.fr/data/full.csv.gz
     nb_threads: # number of threads to use
 #   nb_shards:  # control the number of shards of the ES index
 #   nb_replicas:  # control the number of replicas of the ES index
+
+  # Specify an OSM file to import addresses from.
+  # NOTE: this section will be ignored if `use_deduplicator` is set to false.
+  osm:
+    file: # Path to the .pbf file (ignored if 'url' is defined)
+    url: # https://download.geofabrik.de/europe/luxembourg-latest.osm.pbf
 
 # street:
 #   nb_shards:  # control the number of shards of the ES index


### PR DESCRIPTION
This allow more flexibility in the configuration.

As we download this file in the same directory as the OSM file used for other tasks, the `download` image won't download it a second time if this is redundant.

#### PS

This also solves an issue in the import of OpenAddresses data, the files are imported from `ctx.addresses.oa.path` in opposition to other sources where this would be called `ctx.addresses.[source].file`.

Maybe we should attempt to remove this confusion by renaming everything to `path`, which may be clearer than `file` in the case of OpenAddresses since a directory can be accepted as input?