### PR TITLE
allow to configure multiple OpenAddresses datasets

### DIFF
--- a/docker_settings.yaml
+++ b/docker_settings.yaml
@@ -22,28 +22,27 @@ addresses:
     url: # https://download.geofabrik.de/europe/luxembourg-latest.osm.pbf
 
   oa:
-    # URL for the zip archive containing all data.
-    url: https://data.openaddresses.io/openaddr-collected-europe.zip
-
-    # Patterns of file to import URLs from.
-    include:
-      - lu/**.csv
-      # - at/**.csv
-      # - be/**.csv
-      # - de/**.csv
-      # - dk/**.csv
-      # - ee/**.csv
-      # - es/**.csv
-      # - fi/**.csv
-      # - fr/**.csv
-      # - gr/**.csv
-      # - it/**.csv
-      # - lt/**.csv
-      # - nl/**.csv
-      # - pl/**.csv
-      # - pt/**.csv
-      # - se/**.csv
-      # - si/**.csv
-      # - sk/**.csv
+    datasets:
+      - filename: oa_europe.zip
+        url: https://data.openaddresses.io/openaddr-collected-europe.zip
+        include:
+          - lu/**.csv
+          # - at/**.csv
+          # - be/**.csv
+          # - de/**.csv
+          # - dk/**.csv
+          # - ee/**.csv
+          # - es/**.csv
+          # - fi/**.csv
+          # - fr/**.csv
+          # - gr/**.csv
+          # - it/**.csv
+          # - lt/**.csv
+          # - nl/**.csv
+          # - pl/**.csv
+          # - pt/**.csv
+          # - se/**.csv
+          # - si/**.csv
+          # - sk/**.csv
 
 geocoder_tester_region: luxembourg

--- a/download/tasks.py
+++ b/download/tasks.py
@@ -129,6 +129,11 @@ def file_exists(ctx, path):
 
 
 @task
+def remove_directory(ctx, path):
+    ctx.run(f"rm -rf {path}")
+
+
+@task
 def download_osm(ctx, osm_url, output_file):
     download_file(
         ctx, output_file, osm_url, md5_url=osm_url + ".md5",
@@ -143,8 +148,8 @@ def download_bano(ctx, bano_url, output_file):
 
 
 @task
-def download_oa(ctx, oa_url, oa_filter, output_dir):
-    src_file = path.join(ctx.cache_dir, "oa.zip")
+def download_oa(ctx, filename, oa_url, oa_filter, output_dir):
+    src_file = path.join(ctx.cache_dir, filename)
     download_file(ctx, src_file, oa_url, max_age=timedelta(days=7))
 
     oa_tmp_dir = path.join(ctx.tmp_dir, "oa")
@@ -167,11 +172,9 @@ def download_oa(ctx, oa_url, oa_filter, output_dir):
 
     # Flatten all .csv into output directory.
     print("Collect OpenAddresses data")
-
     ctx.run(f"mkdir -p {output_dir}")
-    ctx.run(f"rm -rf {output_dir}/*")
 
-    for filename in included_files:
-        flat_name = path.relpath(filename, oa_tmp_dir).replace("/", "__")
+    for piece in included_files:
+        flat_name = path.relpath(path.join(filename, piece), oa_tmp_dir).replace("/", "__")
         print(f" -> add {flat_name}")
-        ctx.run(f"mv {filename} {output_dir}/{flat_name}")
+        ctx.run(f"mv {piece} {output_dir}/{flat_name}")

--- a/download/tasks.py
+++ b/download/tasks.py
@@ -148,8 +148,8 @@ def download_bano(ctx, bano_url, output_file):
 
 
 @task
-def download_oa(ctx, filename, oa_url, oa_filter, output_dir):
-    src_file = path.join(ctx.cache_dir, filename)
+def download_oa(ctx, src_filename, oa_url, oa_filter, output_dir):
+    src_file = path.join(ctx.cache_dir, src_filename)
     download_file(ctx, src_file, oa_url, max_age=timedelta(days=7))
 
     oa_tmp_dir = path.join(ctx.tmp_dir, "oa")
@@ -175,6 +175,6 @@ def download_oa(ctx, filename, oa_url, oa_filter, output_dir):
     ctx.run(f"mkdir -p {output_dir}")
 
     for piece in included_files:
-        flat_name = path.relpath(path.join(filename, piece), oa_tmp_dir).replace("/", "__")
+        flat_name = path.join(src_filename, path.relpath(piece, oa_tmp_dir)).replace("/", "__")
         print(f" -> add {flat_name}")
         ctx.run(f"mv {piece} {output_dir}/{flat_name}")

--- a/invoke.yaml
+++ b/invoke.yaml
@@ -60,14 +60,16 @@ addresses:
     output: /data/addresses/output.csv.gz
 
   oa:
-    path: # Path to .csv, or a directory with multiple .csv (ignored if 'url' is defined)
-    url: # Url where to download OpenAddresses data
-    include: # List of file patterns to include from path
-      - lu/**.csv
-      # - fr/**.csv
-    nb_threads: # number of threads to use
-#   nb_shards:  # control the number of shards of the ES index
-#   nb_replicas:  # control the number of replicas of the ES index
+    path:  # change path where to extract dataset
+    nb_threads:  # number of threads to use
+    nb_shards:  # control the number of shards of the ES index
+    nb_replicas:  # control the number of replicas of the ES index
+
+    datasets:
+      - filename:  # unique filename to download to
+        url:  # URL for the zip archive containing all data
+        include:  # list of file patterns to include from path
+          - lu/**.csv
 
   bano:
     file: # Path to the bano file, ignored if url is defined

--- a/tasks.py
+++ b/tasks.py
@@ -81,7 +81,7 @@ def download_addresses(ctx, files=[]):
         for dataset in ctx.addresses.oa.datasets:
             params = [
                 _get_cli_param(ctx.addresses.oa.path, "--output-dir"),
-                _get_cli_param(dataset['filename'], "--filename"),
+                _get_cli_param(dataset['filename'], "--src-filename"),
                 _get_cli_param(dataset['url'], "--oa-url"),
                 _get_cli_param(",".join(dataset['include']), "--oa-filter"),
             ]


### PR DESCRIPTION
The `oa` configuration key now contains a `datasets` fields which specifies a list of sources to import from.

For example we are now able to import data from Switzerland in addition to the regular Europe file:

```yaml
  oa:
    datasets:
      - filename: oa_europe.zip
        url: https://data.openaddresses.io/openaddr-collected-europe.zip
        include:
          - lu/**.csv
          - at/**.csv
      - filename: ch.zip
        url: https://data.openaddresses.io/runs/846846/ch/countrywide.zip
        include: ["*.csv"]
```