### PR TITLE
Add settings to control number of insert threads for mimir

### DIFF
--- a/invoke.yaml
+++ b/invoke.yaml
@@ -64,6 +64,7 @@ addresses:
     nb_threads:  # number of threads to use
     nb_shards:  # control the number of shards of the ES index
     nb_replicas:  # control the number of replicas of the ES index
+#   nb_insert_threads:  # number of threads used to insert in ES database
 
     datasets:
       # - filename:  # unique filename to download to
@@ -77,6 +78,7 @@ addresses:
     nb_threads: # number of threads to use
 #   nb_shards:  # control the number of shards of the ES index
 #   nb_replicas:  # control the number of replicas of the ES index
+#   nb_insert_threads:  # number of threads used to insert in ES database
 
   # Specify an OSM file to import addresses from.
   # NOTE: this section will be ignored if `use_deduplicator` is set to false.

--- a/tasks.py
+++ b/tasks.py
@@ -288,6 +288,7 @@ def load_addresses_base_params(ctx, addr_conf):
         _get_cli_param(addr_conf.get("nb_threads"), "--nb-threads"),
         _get_cli_param(addr_conf.get("nb_shards"), "--nb-shards"),
         _get_cli_param(addr_conf.get("nb_replicas"), "--nb-replicas"),
+        _get_cli_param(addr_conf.get("nb_insert_threads"), "--nb-insert-threads"),
         _get_cli_param(ctx.es, "--connection-string"),
         _get_cli_param(ctx.dataset, "--dataset"),
     ]


### PR DESCRIPTION
Add an option `nb_insert_threads` to configured the number of threads used for insertion into ElasticSearch (cf. https://github.com/CanalTP/mimirsbrunn/pull/403).