### PR TITLE
add an option for number of threads in deduplicator

### DIFF
--- a/invoke.yaml
+++ b/invoke.yaml
@@ -56,6 +56,9 @@ addresses:
     # Use the deduplication to merge addresses from different sources.
     enable: false
 
+    # Number of threads used for computations.
+    # nb_threads:
+
     # Path to output deduplicated addresses to.
     output: /data/addresses/output.csv.gz
 

--- a/tasks.py
+++ b/tasks.py
@@ -260,26 +260,20 @@ def dedupe_addresses(ctx, files=[]):
 
     output_csv = ctx.addresses.deduplication.output
     logging.info("Running addresses importer/deduplicator")
-    options = []
 
-    if ctx.addresses.get("bano", {}).get("file"):
-        options.append("--bano")
-        options.append(ctx.addresses.bano.file)
-    if ctx.addresses.get("oa", {}).get("path"):
-        options.append("--openaddresses")
-        options.append(ctx.addresses.oa.path)
-    if ctx.addresses.get("osm", {}).get("file"):
-        options.append("--osm")
-        options.append(ctx.addresses.osm.file)
+    options = [
+        "--refresh-delay=60000",
+        "--output-compressed-csv=" + output_csv,
+        _get_cli_param(ctx.addresses.get("bano", {}).get("file"), "--bano"),
+        _get_cli_param(ctx.addresses.get("oa", {}).get("path"), "--openaddresses"),
+        _get_cli_param(ctx.addresses.get("osm", {}).get("file"), "--osm"),
+        _get_cli_param(ctx.addresses.deduplication.get("nb_threads"), "--num-threads"),
+    ]
 
     if len(options) == 0:
         logging.info("No dataset to import: aborting addresses deduplication")
         return
 
-    options.append("--refresh-delay")
-    options.append("60000")
-    options.append("--output-compressed-csv")
-    options.append(output_csv)
     run_rust_binary(ctx, "addresses-importer", "", files, " ".join(options))
 
 


### PR DESCRIPTION
Allow to set the `--num-thread` option of the de-duplicator added in https://github.com/QwantResearch/addresses-importer/pull/48